### PR TITLE
Helmdeploy push

### DIFF
--- a/Tasks/HelmDeployV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/HelmDeployV0/Strings/resources.resjson/en-US/resources.resjson
@@ -1,5 +1,5 @@
 {
-  "loc.friendlyName": "Urban Package and deploy Helm charts",
+  "loc.friendlyName": "Package and deploy Helm charts",
   "loc.helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?linkid=851275) or [see the Helm documentation](https://helm.sh/docs/)",
   "loc.description": "Deploy, configure, update a Kubernetes cluster in Azure Container Service by running helm commands",
   "loc.instanceNameFormat": "helm $(command)",
@@ -108,6 +108,6 @@
   "loc.messages.KubernetesServiceConnectionNotFound": "Kubernetes service connection details not found.",
   "loc.messages.ExpiredServicePrincipal": "Could not fetch access token for Azure. Verify if the Service Principal used is valid and not expired.",
   "loc.messages.SaveSupportedInHelmsV3Only": "Save chart to Azure Container Registry is only supported in Helms V3.",
-  "loc.messages.PushSupportedInHelmsV37Only": "Push chart to Azure COntainer Registry is only supported in Helms V3.7 or greater.",
+  "loc.messages.PushSupportedInHelmsV37Only": "Push command to push a chart to Azure Container Registry is only supported in Helm V3.7 or greater.",
   "loc.messages.OutputVariableDataSizeExceeded": "Output variable not set as Helm command output exceeded the maximum supported length. Output length: %s, Maximum supported length: %s"
 }

--- a/Tasks/HelmDeployV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/HelmDeployV0/Strings/resources.resjson/en-US/resources.resjson
@@ -1,5 +1,5 @@
 {
-  "loc.friendlyName": "Package and deploy Helm charts",
+  "loc.friendlyName": "Urban Package and deploy Helm charts",
   "loc.helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?linkid=851275) or [see the Helm documentation](https://helm.sh/docs/)",
   "loc.description": "Deploy, configure, update a Kubernetes cluster in Azure Container Service by running helm commands",
   "loc.instanceNameFormat": "helm $(command)",
@@ -35,7 +35,7 @@
   "loc.input.label.chartName": "Chart Name",
   "loc.input.help.chartName": "Chart reference to install, this can be a url or a chart name. For example, if chart name is 'stable/mysql', the task will run 'helm install stable/mysql'.",
   "loc.input.label.chartPath": "Chart Path",
-  "loc.input.help.chartPath": "Path to the chart to install. This can be a path to a packaged chart or a path to an unpacked chart directory. For example, if './redis' is specified the task will run 'helm install ./redis'.",
+  "loc.input.help.chartPath": "Path to the chart to install or package. This can be a path to a packaged chart or a path to an unpacked chart directory. For example, if './redis' is specified the task will run 'helm install ./redis'.",
   "loc.input.label.version": "Version",
   "loc.input.help.version": "Specify the exact chart version to install. If this is not specified, the latest version is installed. Set the version on the chart to this semver version​",
   "loc.input.label.releaseName": "Release Name",
@@ -84,6 +84,10 @@
   "loc.input.help.chartNameForACR": "Chart name with which the chart will be stored in Azure Container Registry.",
   "loc.input.label.chartPathForACR": "Chart Path for Azure Container Registry",
   "loc.input.help.chartPathForACR": "Path to the chart directory.",
+  "loc.input.label.packagePath": "Path to the packaged chart to push",
+  "loc.input.help.packagePath": "Path to the packaged helm chart to push to Azure Container Registry.",
+  "loc.input.label.acrRepository": "Path to helm repository within Azure Container Registry",
+  "loc.input.help.acrRepository": "Path to the target repository within Azure Container Registry",
   "loc.messages.CantDownloadAccessProfile": "Cannot download access profile/kube config file for the cluster %s. Reason %s.",
   "loc.messages.KubeConfigFilePath": "Kubeconfig file path: %s",
   "loc.messages.KubernetesClusterInfo": "Kubernetes cluster Id : %s, kubernetes server version %s, kuberenettes provision state %s",
@@ -104,5 +108,6 @@
   "loc.messages.KubernetesServiceConnectionNotFound": "Kubernetes service connection details not found.",
   "loc.messages.ExpiredServicePrincipal": "Could not fetch access token for Azure. Verify if the Service Principal used is valid and not expired.",
   "loc.messages.SaveSupportedInHelmsV3Only": "Save chart to Azure Container Registry is only supported in Helms V3.",
+  "loc.messages.PushSupportedInHelmsV37Only": "Push chart to Azure COntainer Registry is only supported in Helms V3.7 or greater.",
   "loc.messages.OutputVariableDataSizeExceeded": "Output variable not set as Helm command output exceeded the maximum supported length. Output length: %s, Maximum supported length: %s"
 }

--- a/Tasks/HelmDeployV0/Tests/L0.ts
+++ b/Tasks/HelmDeployV0/Tests/L0.ts
@@ -280,7 +280,6 @@ describe("HelmDeployV0 Suite", function () {
     });
 
     it("Run successfully with Helm package and push command (version 3)", function (done: Mocha.Done) {
-        console.log("\nStaart new testcase : Helm push \n")
         const tp = path.join(__dirname, "TestSetup.js");
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.command] = shared.Commands.packagepush;

--- a/Tasks/HelmDeployV0/Tests/L0.ts
+++ b/Tasks/HelmDeployV0/Tests/L0.ts
@@ -19,6 +19,7 @@ describe("HelmDeployV0 Suite", function () {
         delete process.env[shared.TestEnvVars.overrideValues];
         delete process.env[shared.TestEnvVars.updatedependency];
         delete process.env[shared.isHelmV3];
+        delete process.env[shared.isHelmV37];
         delete process.env[shared.TestEnvVars.releaseName];
         delete process.env[shared.TestEnvVars.waitForExecution];
         delete process.env[shared.TestEnvVars.arguments];
@@ -28,6 +29,7 @@ describe("HelmDeployV0 Suite", function () {
         delete process.env[shared.TestEnvVars.command];
         delete process.env[shared.TestEnvVars.chartType];
         delete process.env[shared.TestEnvVars.version];
+        delete process.env[shared.TestEnvVars.acrRepository];
     });
 
     after((done) => {
@@ -237,7 +239,7 @@ describe("HelmDeployV0 Suite", function () {
         assert(tr.stdout.indexOf(`Successfully packaged chart and saved it to: ${shared.testDestinationPath}/testChartName.tgz`) != -1, "Chart should have been successfully packaged");
         assert(tr.succeeded, "task should have succeeded");
         done();
-    });
+    }); 
 
     it("Run successfully with Helm save command (version 3)", function (done: Mocha.Done) {
         const tp = path.join(__dirname, "TestSetup.js");
@@ -261,7 +263,42 @@ describe("HelmDeployV0 Suite", function () {
         done();
     });
 
-    it("Helm same should fail (version 2)", function (done: Mocha.Done) {
+    it("Run successfully with Helm push command (version 3)", function (done: Mocha.Done) {
+        const tp = path.join(__dirname, "TestSetup.js");
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        process.env[shared.TestEnvVars.command] = shared.Commands.push;
+        process.env[shared.TestEnvVars.connectionType] = shared.ConnectionTypes.AzureResourceManager;
+        process.env[shared.TestEnvVars.packagePath] = shared.testpackagePath;
+        process.env[shared.TestEnvVars.acrRepository] = shared.testAcrRepository;
+        process.env[shared.TestEnvVars.azureContainerRegistry] = shared.testAzureContainerRegistry;
+        process.env[shared.TestEnvVars.failOnStderr] = "false";
+        process.env[shared.isHelmV37] = "true";
+
+        tr.run();
+        assert(tr.stdout.indexOf(`Successfully pushed chart to: ${shared.testAzureContainerRegistry}/${shared.testAcrRepository}`) != -1, "Chart should have been successfully pushed to ACR registry");
+        done();
+    });
+
+    it("Run successfully with Helm package and push command (version 3)", function (done: Mocha.Done) {
+        console.log("\nStaart new testcase : Helm push \n")
+        const tp = path.join(__dirname, "TestSetup.js");
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        process.env[shared.TestEnvVars.command] = shared.Commands.packagepush;
+        process.env[shared.TestEnvVars.connectionType] = shared.ConnectionTypes.AzureResourceManager;
+        process.env[shared.TestEnvVars.chartPath] = shared.testChartPath;
+        process.env[shared.TestEnvVars.acrRepository] = shared.testAcrRepository;
+        process.env[shared.TestEnvVars.azureContainerRegistry] = shared.testAzureContainerRegistry;
+        process.env[shared.TestEnvVars.failOnStderr] = "false";
+        process.env[shared.isHelmV37] = "true";
+
+        tr.run();
+        assert(tr.stdout.indexOf(`Successfully packaged chart and saved it to: ${process.env[shared.TestEnvVars.chartPath]}/testChartName.tgz`) != -1, "Chart should have been successfully packaged");
+        assert(tr.stdout.indexOf(`Successfully logged in to  ${process.env[shared.TestEnvVars.azureContainerRegistry]}.`) != -1, "Azure container registry login should have been successful."); 
+        assert(tr.stdout.indexOf(`Successfully pushed chart to: ${shared.testAzureContainerRegistry}/${shared.testAcrRepository}`) != -1, "Chart should have been successfully pushed to ACR registry");
+        done();
+    });
+
+    it("Helm save should fail (version 2)", function (done: Mocha.Done) {
         const tp = path.join(__dirname, "TestSetup.js");
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.command] = shared.Commands.save;

--- a/Tasks/HelmDeployV0/Tests/TestSetup.ts
+++ b/Tasks/HelmDeployV0/Tests/TestSetup.ts
@@ -249,14 +249,12 @@ if (process.env[shared.TestEnvVars.command] === shared.Commands.package) {
 
 const helmVersionCommand = "helm version --client --short";
 if (process.env[shared.isHelmV3]) {
-    console.log("\nSetting Helm Version3.2.1 \n")
     a.exec[helmVersionCommand] = {
         "code": 0,
         "stdout": "v3.2.1+ge29ce2a"
     };
 }
 else if (process.env[shared.isHelmV37]) {
-    console.log("\nSetting Helm Version3.7.1 \n")
     a.exec[helmVersionCommand] = {
         "code": 0,
         "stdout": "v3.7.1+g1d11fcb"

--- a/Tasks/HelmDeployV0/Tests/TestSetup.ts
+++ b/Tasks/HelmDeployV0/Tests/TestSetup.ts
@@ -57,6 +57,9 @@ tr.setInput("failOnStderr", process.env[shared.TestEnvVars.failOnStderr] || "tru
 tr.setInput("publishPipelineMetadata", process.env[shared.TestEnvVars.publishPipelineMetadata] || "true");
 tr.setInput("chartNameForACR", process.env[shared.TestEnvVars.chartNameForACR] || "");
 tr.setInput("chartPathForACR", process.env[shared.TestEnvVars.chartPathForACR] || "");
+tr.setInput("acrRepository", process.env[shared.TestEnvVars.acrRepository] || "");
+tr.setInput("packagePath", process.env[shared.TestEnvVars.packagePath] || "");
+
 
 process.env.SYSTEM_DEFAULTWORKINGDIRECTORY = testnamespaceWorkingDirectory;
 process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI = teamFoundationCollectionUri;
@@ -246,9 +249,17 @@ if (process.env[shared.TestEnvVars.command] === shared.Commands.package) {
 
 const helmVersionCommand = "helm version --client --short";
 if (process.env[shared.isHelmV3]) {
+    console.log("\nSetting Helm Version3.2.1 \n")
     a.exec[helmVersionCommand] = {
         "code": 0,
         "stdout": "v3.2.1+ge29ce2a"
+    };
+}
+else if (process.env[shared.isHelmV37]) {
+    console.log("\nSetting Helm Version3.7.1 \n")
+    a.exec[helmVersionCommand] = {
+        "code": 0,
+        "stdout": "v3.7.1+g1d11fcb"
     };
 }
 else {
@@ -317,6 +328,48 @@ a.exec[helmChartRemoveCommand] = {
     "stdout": "Successfully removed the chart from local cache."
 }
 
+if (process.env[shared.TestEnvVars.command] === shared.Commands.push) {
+    let helmPushCommand = `helm push${formatDebugFlag()} ${process.env[shared.TestEnvVars.packagePath]} oci://${process.env[shared.TestEnvVars.azureContainerRegistry]}/${process.env[shared.TestEnvVars.acrRepository]}`;
+
+    a.exec[helmPushCommand] = {
+        "code": 0,
+        "stdout": `Successfully pushed chart to: ${process.env[shared.TestEnvVars.azureContainerRegistry]}/${process.env[shared.TestEnvVars.acrRepository]}`
+    }
+}
+
+if (process.env[shared.TestEnvVars.command] === shared.Commands.packagepush) {
+    let helmPackageCommand = `helm package${formatDebugFlag()}`;
+
+    if (process.env[shared.TestEnvVars.updatedependency])
+        helmPackageCommand = helmPackageCommand.concat(" --dependency-update");
+
+    if (process.env[shared.TestEnvVars.destination])
+        helmPackageCommand = helmPackageCommand.concat(` --destination ${process.env[shared.TestEnvVars.destination]}`);
+
+    if (process.env[shared.TestEnvVars.arguments])
+        helmPackageCommand = helmPackageCommand.concat(` ${process.env[shared.TestEnvVars.arguments]}`);
+
+    if (process.env[shared.TestEnvVars.chartPath])
+        helmPackageCommand = helmPackageCommand.concat(` ${process.env[shared.TestEnvVars.chartPath]}`);
+    a.exec[helmPackageCommand] = {
+        "code": 0,
+        "stdout": `Successfully packaged chart and saved it to: ${process.env[shared.TestEnvVars.chartPath]}/testChartName.tgz`
+    }
+
+    let helmRegistryLoginCommand = `helm registry${formatDebugFlag()} login ${process.env[shared.TestEnvVars.azureContainerRegistry]} --username --password`;
+    a.exec[helmRegistryLoginCommand] = {
+        "code": 0,
+        "stdout": `Successfully logged in to  ${process.env[shared.TestEnvVars.azureContainerRegistry]}.`
+    };
+
+    let helmPushCommand = `helm push${formatDebugFlag()} ${process.env[shared.TestEnvVars.chartPath]}/testChartName.tgz oci://${process.env[shared.TestEnvVars.azureContainerRegistry]}/${process.env[shared.TestEnvVars.acrRepository]}`;
+
+    a.exec[helmPushCommand] = {
+        "code": 0,
+        "stdout": `Successfully pushed chart to: ${process.env[shared.TestEnvVars.azureContainerRegistry]}/${process.env[shared.TestEnvVars.acrRepository]}`
+    }
+}
+
 tr.setAnswers(<any>a);
 tr.registerMock("azure-pipelines-task-lib/toolrunner", require("azure-pipelines-task-lib/mock-toolrunner"));
 
@@ -353,6 +406,7 @@ tr.registerMock('../src/utils', {
 
 import * as webUtil from 'utility-common-v2/restutilities';
 import { command } from 'azure-pipelines-task-lib';
+import { Console } from 'console';
 tr.registerMock('utility-common-v2/restutilities', {
     WebRequest: webUtil.WebRequest,
     WebResponse: webUtil.WebResponse,

--- a/Tasks/HelmDeployV0/Tests/TestShared.ts
+++ b/Tasks/HelmDeployV0/Tests/TestShared.ts
@@ -33,8 +33,10 @@ export let TestEnvVars = {
     arguments: "__arguments__",
     failOnStderr: "__failOnStderr__",
     publishPipelineMetadata: "__publishPipelineMetadata__",
+    acrRepository: "__acrRepository__",
     chartNameForACR: "__chartNameForACR__",
-    chartPathForACR: "__chartPathForACR__"
+    chartPathForACR: "__chartPathForACR__",
+    packagePath: "__packagePath__"
 };
 
 export let Commands = {
@@ -42,7 +44,9 @@ export let Commands = {
     upgrade: "upgrade",
     package: "package",
     save: "save",
-    init: "init"
+    init: "init",
+    push: "push",
+    packagepush: "packagepush",
 };
 
 export let ChartTypes = {
@@ -66,13 +70,16 @@ export const testChartPath = "test/testChartPath";
 export const testChartVersion = "1.1.1";
 export const testReleaseName = "testReleaseName";
 export const isHelmV3 = "__isHelmV3__";
+export const isHelmV37 = "__isHelmV37__";
 export const testNamespace = "testNamespace";
 export const testDestinationPath = "testDestinationPath";
 export const testChartNameForACR = "testChartNameForACR";
+export const testAcrRepository = "test/testPathForACR";
 export const testChartPathForACR = "test/testChartPathForACR";
 export const testAzureResourceGroupForACR = "test-rg";
 export const testAzureSubscriptionEndpointForACR = "RMTest";
 export const testAzureContainerRegistry = "sonayak.azurecr.io";
+export const testpackagePath = "testDestinationPath";
 
 /**
  * Formats the given path to be appropriate for the operating system.

--- a/Tasks/HelmDeployV0/src/helm.ts
+++ b/Tasks/HelmDeployV0/src/helm.ts
@@ -40,12 +40,12 @@ function getClusterType(): any {
 
 function isKubConfigSetupRequired(command: string): boolean {
     var connectionType = tl.getInput("connectionType", true);
-    return command !== "package" && command !== "save" && connectionType !== "None";
+    return command !== "package" && command !== "save"  && command !== "push" && command !== "packagepush" && connectionType !== "None";
 }
 
 function isKubConfigLogoutRequired(command: string): boolean {
     var connectionType = tl.getInput("connectionType", true);
-    return command !== "package" && command !== "save" && command !== "login" && connectionType !== "None";
+    return command !== "package" && command !== "save" && command !== "push" && command !== "packagepush" && command !== "login" && connectionType !== "None";
 }
 
 // get kubeconfig file path
@@ -76,6 +76,21 @@ function runHelmSaveCommand(helmCli: helmcli, kubectlCli: kubernetescli, failOnS
     runHelm(helmCli, "removeChart", kubectlCli, failOnStderr);
 }
 
+function runHelmPackagePushCommand(helmCli: helmcli, kubectlCli: kubernetescli, failOnStderr: boolean): void {
+    if (!helmCli.isHelmV37()) {
+        //helm package and push commands are only supported in Helms v3.7  
+        throw new Error(tl.loc("PushSupportedInHelmsV37Only"));
+    }
+    process.env.HELM_EXPERIMENTAL_OCI="1";
+    runHelm(helmCli, "package", kubectlCli, failOnStderr);
+    helmCli.resetArguments();
+    const chartRef = getHelmChartRefFromPackage(tl.getVariable("helmOutput"));
+    tl.setVariable("helmChartRef", "\""+chartRef+"\"");
+    runHelm(helmCli, "registry", kubectlCli, false);
+    helmCli.resetArguments();
+    runHelm(helmCli, "push", kubectlCli, failOnStderr);
+}
+
 async function run() {
     var command = tl.getInput("command", true).toLowerCase();
     var isKubConfigRequired = isKubConfigSetupRequired(command);
@@ -83,6 +98,9 @@ async function run() {
     if (isKubConfigRequired) {
         var kubeconfigfilePath = command === "logout" ? tl.getVariable("KUBECONFIG") : await getKubeConfigFile();
         kubectlCli = new kubernetescli(kubeconfigfilePath);
+
+        //TODO urban ficht
+        console.log("kubeconfig required - login \n");
         kubectlCli.login();
     }
 
@@ -112,6 +130,9 @@ async function run() {
             case "save":
                 runHelmSaveCommand(helmCli, kubectlCli, failOnStderr);
                 break;
+            case "packagepush":
+                runHelmPackagePushCommand(helmCli, kubectlCli, failOnStderr);
+                break;
             default:
                 runHelm(helmCli, command, kubectlCli, failOnStderr);
         }
@@ -137,21 +158,23 @@ function runHelm(helmCli: helmcli, command: string, kubectlCli: kubernetescli, f
         "registry": "./helmcommands/helmregistrylogin",
         "removeChart": "./helmcommands/helmchartremove",
         "saveChart": "./helmcommands/helmchartsave",
-        "upgrade": "./helmcommands/helmupgrade"
+        "upgrade": "./helmcommands/helmupgrade",
+        "push": "./helmcommands/helmpush"
     }
 
     var commandImplementation = require("./helmcommands/uinotimplementedcommands");
     if (command in helmCommandMap) {
         commandImplementation = require(helmCommandMap[command]);
     }
-
+    
     //set command
     if (command === "saveChart" || command === "pushChart" || command === "removeChart") {
         helmCli.setCommand("chart");
     } else {
         helmCli.setCommand(command);
     }
-
+    //TODO Urban
+    console.log(`\n\n\n Befehl1: ${helmCli.getCommand()} ${helmCli.getArguments()} \n\n\n`);
     // add arguments
     commonCommandOptions.addArguments(helmCli);
     commandImplementation.addArguments(helmCli);
@@ -248,5 +271,15 @@ function getHelmChartRef(helmOutput: string): string {
     const lineEndingIndex = helmOutput.indexOf("\n", refIndex);
     let helmRef = helmOutput.substring(refIndex + refMarker.length, lineEndingIndex);
     helmRef.trim();
+    return helmRef;
+}
+
+function getHelmChartRefFromPackage(helmOutput: string): string {
+    const refMarker = "Successfully packaged chart and saved it to: ";
+    const refIndex = helmOutput.indexOf(refMarker);
+    let helmRef = helmOutput.substring(refIndex + refMarker.length);
+    helmRef.trim();
+    console.log("\n"+helmRef+"\n");
+    console.log("\n"+refIndex +" "+ refMarker.length +"\n");
     return helmRef;
 }

--- a/Tasks/HelmDeployV0/src/helm.ts
+++ b/Tasks/HelmDeployV0/src/helm.ts
@@ -98,9 +98,6 @@ async function run() {
     if (isKubConfigRequired) {
         var kubeconfigfilePath = command === "logout" ? tl.getVariable("KUBECONFIG") : await getKubeConfigFile();
         kubectlCli = new kubernetescli(kubeconfigfilePath);
-
-        //TODO urban ficht
-        console.log("kubeconfig required - login \n");
         kubectlCli.login();
     }
 
@@ -173,8 +170,6 @@ function runHelm(helmCli: helmcli, command: string, kubectlCli: kubernetescli, f
     } else {
         helmCli.setCommand(command);
     }
-    //TODO Urban
-    console.log(`\n\n\n Befehl1: ${helmCli.getCommand()} ${helmCli.getArguments()} \n\n\n`);
     // add arguments
     commonCommandOptions.addArguments(helmCli);
     commandImplementation.addArguments(helmCli);
@@ -279,7 +274,5 @@ function getHelmChartRefFromPackage(helmOutput: string): string {
     const refIndex = helmOutput.indexOf(refMarker);
     let helmRef = helmOutput.substring(refIndex + refMarker.length);
     helmRef.trim();
-    console.log("\n"+helmRef+"\n");
-    console.log("\n"+refIndex +" "+ refMarker.length +"\n");
     return helmRef;
 }

--- a/Tasks/HelmDeployV0/src/helmcli.ts
+++ b/Tasks/HelmDeployV0/src/helmcli.ts
@@ -65,6 +65,20 @@ export default class helmcli extends basecommand {
         return false;
     }
 
+    /*
+    checks for helm version 3 and minor version 7 or higher
+    */
+    public isHelmV37(): boolean {
+        if (this.isHelmV3()){
+            let minorversion = this.helmVersion;
+            // get minor version 3.7.0 -> "7"
+            minorversion = minorversion.slice(minorversion.indexOf('.')+1,minorversion.lastIndexOf('.'));
+            if (Number(minorversion) >= 7)
+                return true;
+        }
+        return false;
+    }
+
     public execHelmCommand(silent?: boolean): tr.IExecSyncResult {
         var command = this.createCommand();
         command.arg(this.command);

--- a/Tasks/HelmDeployV0/src/helmcommands/helmpush.ts
+++ b/Tasks/HelmDeployV0/src/helmcommands/helmpush.ts
@@ -9,18 +9,16 @@ Pushs a helm chart to ACR (requires helm version 3.7.0 or higher)
 */
 
 export function addArguments(helmCli: helmcli): void {
-    console.log(`pushcommand - URBAN \n`);
     if (!helmCli.isHelmV37()) {
         //helm chart save and push commands are only supported in Helms v3  
         throw new Error(tl.loc("PushSupportedInHelmsV7Only"));
     }
     process.env.HELM_EXPERIMENTAL_OCI="1";
+    
     // path to packaged helm chart
     if (!tl.getVariable("helmChartRef")){
          tl.setVariable("helmChartRef","\"" + tl.getInput("packagePath",true) + "\"");
-         console.log(tl.getVariable("helmChartRef")+"\n");
     }
-    console.log("helmchartref"+tl.getVariable("helmChartRef")+"\n");
     helmCli.addArgument(tl.getVariable("helmChartRef"));
     const acrRepository = tl.getInput("acrRepository",true);
     const azureContainerRegistry = tl.getInput("azureContainerRegistry",true);

--- a/Tasks/HelmDeployV0/src/helmcommands/helmpush.ts
+++ b/Tasks/HelmDeployV0/src/helmcommands/helmpush.ts
@@ -1,0 +1,29 @@
+"use strict";
+
+import tl = require('azure-pipelines-task-lib/task');
+import { SSL_OP_NO_TLSv1_1 } from 'constants';
+import helmcli from "../helmcli";
+
+/*
+Pushs a helm chart to ACR (requires helm version 3.7.0 or higher)
+*/
+
+export function addArguments(helmCli: helmcli): void {
+    console.log(`pushcommand - URBAN \n`);
+    if (!helmCli.isHelmV37()) {
+        //helm chart save and push commands are only supported in Helms v3  
+        throw new Error(tl.loc("PushSupportedInHelmsV7Only"));
+    }
+    process.env.HELM_EXPERIMENTAL_OCI="1";
+    // path to packaged helm chart
+    if (!tl.getVariable("helmChartRef")){
+         tl.setVariable("helmChartRef","\"" + tl.getInput("packagePath",true) + "\"");
+         console.log(tl.getVariable("helmChartRef")+"\n");
+    }
+    console.log("helmchartref"+tl.getVariable("helmChartRef")+"\n");
+    helmCli.addArgument(tl.getVariable("helmChartRef"));
+    const acrRepository = tl.getInput("acrRepository",true);
+    const azureContainerRegistry = tl.getInput("azureContainerRegistry",true);
+    helmCli.addArgument("oci://"+azureContainerRegistry+"/"+acrRepository);
+
+}

--- a/Tasks/HelmDeployV0/task.json
+++ b/Tasks/HelmDeployV0/task.json
@@ -1,7 +1,8 @@
 {
-    "id": "AFA7D54D-537B-4DC8-B60A-E0EEEA2C9A87",
-    "name": "HelmDeploy",
-    "friendlyName": "Package and deploy Helm charts",
+    "$schema": "https://raw.githubusercontent.com/Microsoft/azure-pipelines-task-lib/master/tasks.schema.json",
+    "id": "1FA7D54D-537B-4DC8-B60A-E0EEEA2C9A87",
+    "name": "HelmDeployTEST",
+    "friendlyName": "Urban Package and deploy Helm charts",
     "description": "Deploy, configure, update a Kubernetes cluster in Azure Container Service by running helm commands",
     "helpUrl": "https://aka.ms/azpipes-helm-tsg",
     "helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?linkid=851275) or [see the Helm documentation](https://helm.sh/docs/)",
@@ -10,10 +11,10 @@
         "Build",
         "Release"
     ],
-    "author": "Microsoft Corporation",
+    "author": "Urban Ficht",
     "version": {
         "Major": 0,
-        "Minor": 183,
+        "Minor": 195,
         "Patch": 0
     },
     "demands": [],
@@ -22,7 +23,7 @@
             "name": "cluster",
             "displayName": "Kubernetes Cluster",
             "isExpanded": true,
-            "visibleRule": "command != logout && command != package && command != save"
+            "visibleRule": "command != logout && command != package && command != save && command != push && command != packagepush"
         },
         {
             "name": "commands",
@@ -33,19 +34,19 @@
             "name": "azureContainerRegistry",
             "displayName": "Azure Container Registry",
             "isExpanded": true,
-            "visibleRule": "command == save"
+            "visibleRule": "command == save || command == push || command == packagepush"
         },
         {
             "name": "tls",
             "displayName": "TLS",
             "isExpanded": false,
-            "visibleRule": "command != login && command != logout && command != package && command != save"
+            "visibleRule": "command != login && command != logout && command != package && command != save && command != push && command != packagepush"
         },
         {
             "name": "advanced",
             "displayName": "Advanced",
             "isExpanded": false,
-            "visibleRule": "command != login && command != logout && command != package && command != save"
+            "visibleRule": "command != login && command != logout && command != package && command != save  && command != push && command != packagepush"
         }
     ],
     "inputs": [
@@ -184,7 +185,9 @@
                 "rollback": "rollback",
                 "save": "save",
                 "upgrade": "upgrade",
-                "uninstall": "uninstall"
+                "uninstall": "uninstall",
+                "push":"push",
+                "packagepush":"packagepush"
             },
             "helpMarkDown": "Select a helm command.",
             "groupName": "commands",
@@ -223,9 +226,9 @@
             "name": "chartPath",
             "label": "Chart Path",
             "type": "filePath",
-            "helpMarkDown": "Path to the chart to install. This can be a path to a packaged chart or a path to an unpacked chart directory. For example, if './redis' is specified the task will run 'helm install ./redis'.",
+            "helpMarkDown": "Path to the chart to install or package. This can be a path to a packaged chart or a path to an unpacked chart directory. For example, if './redis' is specified the task will run 'helm install ./redis'.",
             "defaultValue": "",
-            "visibleRule": "chartType == FilePath || command == package",
+            "visibleRule": "chartType == FilePath || command == package || command == packagepush",
             "required": "true",
             "groupName": "commands"
         },
@@ -462,6 +465,26 @@
             "visibleRule": "command == save",
             "required": "true",
             "groupName": "commands"
+        },
+        {
+            "name": "packagePath",
+            "label": "Path to the packaged chart to push",
+            "type": "filePath",
+            "helpMarkDown": "Path to the packaged helm chart to push to Azure Container Registry.",
+            "defaultValue": "",
+            "visibleRule": "command == push",
+            "required": "true",
+            "groupName": "commands"
+        },
+        {
+            "name": "acrRepository",
+            "label": "Path to helm repository within Azure Container Registry",
+            "type": "string",
+            "helpMarkDown": "Path to the target repository within Azure Container Registry",
+            "defaultValue": "",
+            "visibleRule": "command == push || command == packagepush",
+            "required": "true",
+            "groupName": "commands"
         }
     ],
     "dataSourceBindings": [
@@ -542,6 +565,7 @@
         "KubernetesServiceConnectionNotFound": "Kubernetes service connection details not found.",
         "ExpiredServicePrincipal": "Could not fetch access token for Azure. Verify if the Service Principal used is valid and not expired.",
         "SaveSupportedInHelmsV3Only": "Save chart to Azure Container Registry is only supported in Helms V3.",
+        "PushSupportedInHelmsV37Only": "Push command to push a chart to Azure Container Registry is only supported in Helm V3.7 or greater.",
         "OutputVariableDataSizeExceeded": "Output variable not set as Helm command output exceeded the maximum supported length. Output length: %s, Maximum supported length: %s"
     }
 }

--- a/Tasks/HelmDeployV0/task.json
+++ b/Tasks/HelmDeployV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 184,
+        "Minor": 198,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/HelmDeployV0/task.json
+++ b/Tasks/HelmDeployV0/task.json
@@ -1,8 +1,7 @@
 {
-    "$schema": "https://raw.githubusercontent.com/Microsoft/azure-pipelines-task-lib/master/tasks.schema.json",
-    "id": "1FA7D54D-537B-4DC8-B60A-E0EEEA2C9A87",
-    "name": "HelmDeployTEST",
-    "friendlyName": "Urban Package and deploy Helm charts",
+    "id": "AFA7D54D-537B-4DC8-B60A-E0EEEA2C9A87",
+    "name": "HelmDeploy",
+    "friendlyName": "Package and deploy Helm charts",
     "description": "Deploy, configure, update a Kubernetes cluster in Azure Container Service by running helm commands",
     "helpUrl": "https://aka.ms/azpipes-helm-tsg",
     "helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?linkid=851275) or [see the Helm documentation](https://helm.sh/docs/)",
@@ -11,10 +10,10 @@
         "Build",
         "Release"
     ],
-    "author": "Urban Ficht",
+    "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 195,
+        "Minor": 184,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/HelmDeployV0/task.loc.json
+++ b/Tasks/HelmDeployV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 183,
+    "Minor": 198,
     "Patch": 0
   },
   "demands": [],
@@ -22,7 +22,7 @@
       "name": "cluster",
       "displayName": "ms-resource:loc.group.displayName.cluster",
       "isExpanded": true,
-      "visibleRule": "command != logout && command != package && command != save"
+      "visibleRule": "command != logout && command != package && command != save && command != push && command != packagepush"
     },
     {
       "name": "commands",
@@ -33,19 +33,19 @@
       "name": "azureContainerRegistry",
       "displayName": "ms-resource:loc.group.displayName.azureContainerRegistry",
       "isExpanded": true,
-      "visibleRule": "command == save"
+      "visibleRule": "command == save || command == push || command == packagepush"
     },
     {
       "name": "tls",
       "displayName": "ms-resource:loc.group.displayName.tls",
       "isExpanded": false,
-      "visibleRule": "command != login && command != logout && command != package && command != save"
+      "visibleRule": "command != login && command != logout && command != package && command != save && command != push && command != packagepush"
     },
     {
       "name": "advanced",
       "displayName": "ms-resource:loc.group.displayName.advanced",
       "isExpanded": false,
-      "visibleRule": "command != login && command != logout && command != package && command != save"
+      "visibleRule": "command != login && command != logout && command != package && command != save  && command != push && command != packagepush"
     }
   ],
   "inputs": [
@@ -184,7 +184,9 @@
         "rollback": "rollback",
         "save": "save",
         "upgrade": "upgrade",
-        "uninstall": "uninstall"
+        "uninstall": "uninstall",
+        "push": "push",
+        "packagepush": "packagepush"
       },
       "helpMarkDown": "ms-resource:loc.input.help.command",
       "groupName": "commands",
@@ -225,7 +227,7 @@
       "type": "filePath",
       "helpMarkDown": "ms-resource:loc.input.help.chartPath",
       "defaultValue": "",
-      "visibleRule": "chartType == FilePath || command == package",
+      "visibleRule": "chartType == FilePath || command == package || command == packagepush",
       "required": "true",
       "groupName": "commands"
     },
@@ -462,6 +464,26 @@
       "visibleRule": "command == save",
       "required": "true",
       "groupName": "commands"
+    },
+    {
+      "name": "packagePath",
+      "label": "ms-resource:loc.input.label.packagePath",
+      "type": "filePath",
+      "helpMarkDown": "ms-resource:loc.input.help.packagePath",
+      "defaultValue": "",
+      "visibleRule": "command == push",
+      "required": "true",
+      "groupName": "commands"
+    },
+    {
+      "name": "acrRepository",
+      "label": "ms-resource:loc.input.label.acrRepository",
+      "type": "string",
+      "helpMarkDown": "ms-resource:loc.input.help.acrRepository",
+      "defaultValue": "",
+      "visibleRule": "command == push || command == packagepush",
+      "required": "true",
+      "groupName": "commands"
     }
   ],
   "dataSourceBindings": [
@@ -542,6 +564,7 @@
     "KubernetesServiceConnectionNotFound": "ms-resource:loc.messages.KubernetesServiceConnectionNotFound",
     "ExpiredServicePrincipal": "ms-resource:loc.messages.ExpiredServicePrincipal",
     "SaveSupportedInHelmsV3Only": "ms-resource:loc.messages.SaveSupportedInHelmsV3Only",
+    "PushSupportedInHelmsV37Only": "ms-resource:loc.messages.PushSupportedInHelmsV37Only",
     "OutputVariableDataSizeExceeded": "ms-resource:loc.messages.OutputVariableDataSizeExceeded"
   }
 }


### PR DESCRIPTION
**Task name**: HelmDeployV0

**Description**:
 The 3.7.0 version of the helm tool introduced a new push command and debricated save chart. 
 The push command was added to the task aswell as the combined option packagepush. 
 The packagepush option will package a helm chart, login to a registry and push the chart to it using the OCI-feature.

**Documentation changes required:** (Y) 
a new command was introduced as well as new parameters in the task

**Added unit tests:** (Y) <Please mark if unit tests were added or updated according changes>
Included unit test for push and packagepush option

**Attached related issue:** (Y) 
[tasks need update for helm breaking changes #15288](https://github.com/microsoft/azure-pipelines-tasks/issues/15288) 

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected

Urban Ficht <urban.ficht@daimler.com> on behalf of Daimler TSS GmbH

[PROVIDER_INFORMATION](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)


